### PR TITLE
Improve Astro SEO metadata foundation

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://murek.dev/sitemap-index.xml

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -9,8 +9,11 @@ interface Props {
   siteTitle?: string;
   description: string;
   image?: string | URL;
+  ogType?: "website" | "article";
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
   article?: {
     publishedTime: Date;
+    modifiedTime?: Date;
     author?: string;
     tags?: string[];
   };
@@ -25,6 +28,8 @@ const {
   siteTitle = "Marek Kaput",
   description,
   image = "https://www.gravatar.com/avatar/28368724d65db3b992c4a2f44c7b4bae71f72c6b03f35c921a4d96846f768ebd?s=1200",
+  ogType,
+  jsonLd,
   article,
   bodyClass,
 } = Astro.props;
@@ -35,6 +40,7 @@ const fullTitle = title ? `${title} | ${siteTitle}` : siteTitle;
 const shortTitle = title || siteTitle;
 
 const hasCustomImage = !!Astro.props.image;
+const resolvedOgType = ogType ?? (article ? "article" : "website");
 ---
 
 <!doctype html>
@@ -44,10 +50,14 @@ const hasCustomImage = !!Astro.props.image;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <title>{fullTitle}</title>
+    <meta property="og:type" content={resolvedOgType} />
     <meta property="og:title" content={shortTitle} />
     <meta property="og:site_name" content={siteTitle} />
-    <meta property="twitter:site" content="@jajakobyly" />
-    <meta property="twitter:creator" content="@jajakobyly" />
+    <meta name="twitter:title" content={shortTitle} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={image} />
+    <meta name="twitter:site" content="@jajakobyly" />
+    <meta name="twitter:creator" content="@jajakobyly" />
     <meta property="og:locale" content={lang} />
     <meta name="description" content={description} />
     <meta property="og:description" content={description} />
@@ -70,10 +80,26 @@ const hasCustomImage = !!Astro.props.image;
             property="article:published_time"
             content={article.publishedTime.toISOString()}
           />
+          {article.modifiedTime && (
+            <meta
+              property="article:modified_time"
+              content={article.modifiedTime.toISOString()}
+            />
+          )}
           {article.tags?.map((tag) => (
             <meta property="article:tag" content={tag} />
           ))}
         </>
+      )
+    }
+
+    {
+      jsonLd && (
+        <script
+          is:inline
+          type="application/ld+json"
+          set:html={JSON.stringify(jsonLd)}
+        />
       )
     }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,10 +10,43 @@ import blackHoleWebm from "../assets/black-hole.webm";
 import { getUnifiedPosts } from "../lib/posts";
 
 const posts = await getUnifiedPosts();
+const websiteUrl = Astro.site?.toString() || "https://murek.dev";
+const personUrl = `${websiteUrl}#marek-kaput`;
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": `${websiteUrl}#website`,
+      url: websiteUrl,
+      name: "Marek Kaput",
+      description:
+        "Skilled Rustacean and technology polyglot building complex software and teams.",
+      inLanguage: "en",
+      publisher: {
+        "@id": personUrl,
+      },
+    },
+    {
+      "@type": "Person",
+      "@id": personUrl,
+      name: "Marek Kaput",
+      url: websiteUrl,
+      jobTitle: "Software Engineer",
+      sameAs: [
+        "https://github.com/mkaput",
+        "https://x.com/jajakobyly",
+        "https://www.linkedin.com/in/marek-kaput/",
+      ],
+      knowsAbout: ["Rust", "Elixir", "Agentic coding", "Software architecture"],
+    },
+  ],
+};
 ---
 
 <RootLayout
   title={false}
+  jsonLd={websiteJsonLd}
   description={"Skilled Rustacean and technology polyglot. " +
     "Having a great track record of building complex software from nothing " +
     "and establishing development teams working on it."}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,69 +11,55 @@ import { getUnifiedPosts } from "../lib/posts";
 
 const posts = await getUnifiedPosts();
 
-const githubProfileUrl = "https://github.com/mkaput";
-const linkedInProfileUrl = "https://www.linkedin.com/in/marek-kaput/";
-const xProfileUrl = "https://x.com/jajakobyly";
-
-const websiteUrl = Astro.site!;
-const websiteId = `${websiteUrl}#website`;
-const profilePageId = `${websiteUrl}#profilepage`;
-const personId = `${websiteUrl}#person`;
-const organizationId = `${websiteUrl}#organization`;
-const avatarId = `${websiteUrl}#avatar`;
-
-const fullName = "Marek Kaput";
-const avatarUrl =
-  "https://www.gravatar.com/avatar/28368724d65db3b992c4a2f44c7b4bae71f72c6b03f35c921a4d96846f768ebd?s=1200";
-const addressLocality = "Kraków";
-const organizationName = "Software Mansion";
-const organizationUrl = "https://swmansion.com";
-
 const websiteJsonLd = {
   "@context": "https://schema.org",
   "@graph": [
     {
       "@type": "WebSite",
-      "@id": websiteId,
-      url: websiteUrl,
-      name: fullName,
+      "@id": `${Astro.site!}#website`,
+      url: Astro.site!,
+      name: "Marek Kaput",
       inLanguage: "en",
     },
     {
       "@type": "ProfilePage",
-      "@id": profilePageId,
-      url: websiteUrl,
-      name: `${fullName} | Software Engineer`,
+      "@id": `${Astro.site!}#profilepage`,
+      url: Astro.site!,
+      name: "Marek Kaput | Software Engineer",
       inLanguage: "en",
       isPartOf: {
-        "@id": websiteId,
+        "@id": `${Astro.site!}#website`,
       },
       about: {
-        "@id": personId,
+        "@id": `${Astro.site!}#person`,
       },
       primaryImageOfPage: {
-        "@id": avatarId,
+        "@id": `${Astro.site!}#avatar`,
       },
     },
     {
       "@type": "Person",
-      "@id": personId,
-      name: fullName,
-      url: websiteUrl,
+      "@id": `${Astro.site!}#person`,
+      name: "Marek Kaput",
+      url: Astro.site!,
       image: {
-        "@id": avatarId,
+        "@id": `${Astro.site!}#avatar`,
       },
       jobTitle: "Senior Software Engineer",
       description:
         "Senior software engineer focused on Rust, distributed systems, compiler and developer tooling, and AI-powered agentic engineering.",
       address: {
         "@type": "PostalAddress",
-        addressLocality,
+        addressLocality: "Kraków",
         addressCountry: "PL",
       },
-      sameAs: [githubProfileUrl, linkedInProfileUrl, xProfileUrl],
+      sameAs: [
+        "https://github.com/mkaput",
+        "https://www.linkedin.com/in/marek-kaput/",
+        "https://x.com/jajakobyly",
+      ],
       worksFor: {
-        "@id": organizationId,
+        "@id": `${Astro.site!}#organization`,
       },
       knowsAbout: [
         "Rust",
@@ -86,21 +72,22 @@ const websiteJsonLd = {
         "Agentic workflows",
       ],
       mainEntityOfPage: {
-        "@id": profilePageId,
+        "@id": `${Astro.site!}#profilepage`,
       },
     },
     {
       "@type": "Organization",
-      "@id": organizationId,
-      name: organizationName,
-      url: organizationUrl,
+      "@id": `${Astro.site!}#organization`,
+      name: "Software Mansion",
+      url: "https://swmansion.com",
     },
     {
       "@type": "ImageObject",
-      "@id": avatarId,
-      url: avatarUrl,
-      contentUrl: avatarUrl,
-      caption: fullName,
+      "@id": `${Astro.site!}#avatar`,
+      url: "https://www.gravatar.com/avatar/28368724d65db3b992c4a2f44c7b4bae71f72c6b03f35c921a4d96846f768ebd?s=1200",
+      contentUrl:
+        "https://www.gravatar.com/avatar/28368724d65db3b992c4a2f44c7b4bae71f72c6b03f35c921a4d96846f768ebd?s=1200",
+      caption: "Marek Kaput",
     },
   ],
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,35 +10,116 @@ import blackHoleWebm from "../assets/black-hole.webm";
 import { getUnifiedPosts } from "../lib/posts";
 
 const posts = await getUnifiedPosts();
-const websiteUrl = Astro.site?.toString() || "https://murek.dev";
-const personUrl = `${websiteUrl}#marek-kaput`;
+
+const githubProfileUrl = "https://github.com/mkaput";
+const linkedInProfileUrl = "https://www.linkedin.com/in/marek-kaput/";
+const xProfileUrl = "https://x.com/jajakobyly";
+
+const websiteUrl = new URL(
+  "/",
+  Astro.site?.toString() ?? "https://murek.dev",
+).toString();
+const websiteId = `${websiteUrl}#website`;
+const profilePageId = `${websiteUrl}#profilepage`;
+const personId = `${websiteUrl}#person`;
+const organizationId = `${websiteUrl}#organization`;
+const avatarId = `${websiteUrl}#avatar`;
+
+const githubProfile = await fetch("https://api.github.com/users/mkaput")
+  .then(async (response) => {
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as {
+      avatar_url?: string;
+      name?: string;
+      location?: string;
+    };
+  })
+  .catch(() => null);
+
+const fullName = githubProfile?.name || "Marek Kaput";
+const avatarUrl =
+  githubProfile?.avatar_url ||
+  "https://www.gravatar.com/avatar/28368724d65db3b992c4a2f44c7b4bae71f72c6b03f35c921a4d96846f768ebd?s=1200";
+const location = githubProfile?.location || "Kraków, Poland";
+const addressLocality = location.split(",")[0]?.trim() || "Kraków";
+const organizationName = "Software Mansion";
+const organizationUrl = "https://swmansion.com";
+
 const websiteJsonLd = {
   "@context": "https://schema.org",
   "@graph": [
     {
       "@type": "WebSite",
-      "@id": `${websiteUrl}#website`,
+      "@id": websiteId,
       url: websiteUrl,
-      name: "Marek Kaput",
-      description:
-        "Skilled Rustacean and technology polyglot building complex software and teams.",
+      name: fullName,
       inLanguage: "en",
-      publisher: {
-        "@id": personUrl,
+    },
+    {
+      "@type": "ProfilePage",
+      "@id": profilePageId,
+      url: websiteUrl,
+      name: `${fullName} | Software Engineer`,
+      inLanguage: "en",
+      isPartOf: {
+        "@id": websiteId,
+      },
+      about: {
+        "@id": personId,
+      },
+      primaryImageOfPage: {
+        "@id": avatarId,
       },
     },
     {
       "@type": "Person",
-      "@id": personUrl,
-      name: "Marek Kaput",
+      "@id": personId,
+      name: fullName,
       url: websiteUrl,
-      jobTitle: "Software Engineer",
-      sameAs: [
-        "https://github.com/mkaput",
-        "https://x.com/jajakobyly",
-        "https://www.linkedin.com/in/marek-kaput/",
+      image: {
+        "@id": avatarId,
+      },
+      jobTitle: "Senior Software Engineer",
+      description:
+        "Senior software engineer focused on Rust, distributed systems, compiler and developer tooling, and AI-powered agentic engineering.",
+      address: {
+        "@type": "PostalAddress",
+        addressLocality,
+        addressCountry: "PL",
+      },
+      sameAs: [githubProfileUrl, linkedInProfileUrl, xProfileUrl],
+      worksFor: {
+        "@id": organizationId,
+      },
+      knowsAbout: [
+        "Rust",
+        "Distributed systems",
+        "Compilers",
+        "Developer tooling",
+        "Elixir",
+        "Systems architecture",
+        "AI engineering",
+        "Agentic workflows",
       ],
-      knowsAbout: ["Rust", "Elixir", "Agentic coding", "Software architecture"],
+      mainEntityOfPage: {
+        "@id": profilePageId,
+      },
+    },
+    {
+      "@type": "Organization",
+      "@id": organizationId,
+      name: organizationName,
+      url: organizationUrl,
+    },
+    {
+      "@type": "ImageObject",
+      "@id": avatarId,
+      url: avatarUrl,
+      contentUrl: avatarUrl,
+      caption: fullName,
     },
   ],
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,36 +15,17 @@ const githubProfileUrl = "https://github.com/mkaput";
 const linkedInProfileUrl = "https://www.linkedin.com/in/marek-kaput/";
 const xProfileUrl = "https://x.com/jajakobyly";
 
-const websiteUrl = new URL(
-  "/",
-  Astro.site?.toString() ?? "https://murek.dev",
-).toString();
+const websiteUrl = Astro.site!;
 const websiteId = `${websiteUrl}#website`;
 const profilePageId = `${websiteUrl}#profilepage`;
 const personId = `${websiteUrl}#person`;
 const organizationId = `${websiteUrl}#organization`;
 const avatarId = `${websiteUrl}#avatar`;
 
-const githubProfile = await fetch("https://api.github.com/users/mkaput")
-  .then(async (response) => {
-    if (!response.ok) {
-      return null;
-    }
-
-    return (await response.json()) as {
-      avatar_url?: string;
-      name?: string;
-      location?: string;
-    };
-  })
-  .catch(() => null);
-
-const fullName = githubProfile?.name || "Marek Kaput";
+const fullName = "Marek Kaput";
 const avatarUrl =
-  githubProfile?.avatar_url ||
   "https://www.gravatar.com/avatar/28368724d65db3b992c4a2f44c7b4bae71f72c6b03f35c921a4d96846f768ebd?s=1200";
-const location = githubProfile?.location || "Kraków, Poland";
-const addressLocality = location.split(",")[0]?.trim() || "Kraków";
+const addressLocality = "Kraków";
 const organizationName = "Software Mansion";
 const organizationUrl = "https://swmansion.com";
 


### PR DESCRIPTION
### Motivation
- Align the site with the Astro SEO checklist by adding missing SEO primitives for social sharing and structured data so pages are discoverable and shareable.
- Provide a simple, page-level mechanism for JSON-LD so structured data can be emitted from pages without external plugins.

### Description
- Add optional `ogType` and `jsonLd` props to `src/layouts/RootLayout.astro` and resolve `og:type` to `article` when article data is present, otherwise `website`.
- Emit explicit Twitter metadata (`twitter:title`, `twitter:description`, `twitter:image`, `twitter:site`, `twitter:creator`) and support `article:modified_time` when present.
- Render page-provided JSON-LD via an `is:inline` `<script type="application/ld+json" set:html={...}>` to avoid escaping and allow raw structured data injection.
- Add homepage structured data (`WebSite` + `Person` @graph) in `src/pages/index.astro` and pass it to the layout as `jsonLd`.
- Add a basic `public/robots.txt` that allows crawling and points to the generated `sitemap-index.xml`.
- Files changed: `src/layouts/RootLayout.astro`, `src/pages/index.astro`, `public/robots.txt`.

### Testing
- Ran `bun format src/layouts/RootLayout.astro src/pages/index.astro public/robots.txt` which succeeded and formatted the modified files.
- Ran `bun run build` which completed successfully and produced `sitemap-index.xml` while emitting environment warnings about font provider network access and an empty internal `posts` collection (existing repository state).
- Ran `bun check` which reported a pre-existing `astro.config.ts` Vite plugin typing mismatch and font provider network fetch failures, causing the typecheck to fail (issue is unrelated to these SEO changes).
- Performed a headless browser validation (Playwright) against the local dev server and confirmed `meta[property="og:type"]` is present (`website`) and one `script[type="application/ld+json"]` is present on the homepage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34940df4c832db2291bbc869ecd12)